### PR TITLE
Support direct execution of a named command sequence, skipping dialog.

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="script.commands"
        name="Commands"
-       version="1.0.3"
+       version="1.0.4"
        provider-name="AddonScriptorDE">
   <requires>
     <import addon="xbmc.python" version="2.1.0"/>
@@ -11,11 +11,36 @@
     <provides>executable</provides>
   </extension>
   <extension point="xbmc.addon.metadata">
-      <summary lang="en">Map multiple XBMC commands to one remote button. All availabe commands: http://wiki.xbmc.org/?title=List_of_Built_In_Functions</summary>
-      <summary lang="de">Mehrere XBMC Befehle einer Taste zuweisen. Alle verfügbaren Befehle: http://wiki.xbmc.org/?title=List_of_Built_In_Functions</summary>
+      <summary lang="en">Map multiple XBMC commands to one remote button</summary>
+      <summary lang="de">Mehrere XBMC Befehle einer Taste zuweisen</summary>
       <language></language>
-      <description lang="en">Map multiple XBMC commands to one remote button. All availabe commands: http://wiki.xbmc.org/?title=List_of_Built_In_Functions</description>
-      <description lang="de">Mehrere XBMC Befehle einer Taste zuweisen. Alle verfügbaren Befehle: http://wiki.xbmc.org/?title=List_of_Built_In_Functions</description>
+      <description lang="en">
+          Map multiple XBMC commands to one remote button. All availabe commands: http://wiki.xbmc.org/?title=List_of_Built_In_Functions
+
+          Simple Usage: Define one or more command sequences using the menus of this AddOn,
+            then use the Keymap Editor AddOn to assign a key to the Commands Addon.
+            This method causes a command sequence selection menu to be shown on keypress.
+
+          Advanced Invocation Examples: (Edit the keymap file):
+            - Directly invoke a command sequence on keypress, name is the value you assigned to it in the menus:
+            RunScript(script.commands,,&amp;name=NAME-OF-YOUR-COMMAND-SEQUENCE)
+            - Specify a different set of commands (works with or without the name parameter)
+            RunScript(script.commands,,&amp;key=NAME-OF-DIFFERENT-COMMAND-SET&amp;name=NAME-OF-YOUR-COMMAND-SEQUENCE)
+
+      </description>
+      <description lang="de">
+          Mehrere XBMC Befehle einer Taste zuweisen. Alle verfügbaren Befehle: http://wiki.xbmc.org/?title=List_of_Built_In_Functions
+
+          Einfache Verwendung: Definieren Sie eine oder mehrere Befehlsfolgen mit den Menüs dieses AddOn,
+             Verwenden Sie dann den Keymap Editor AddOn, um dem Command Addon einen Schlüssel zuzuweisen.
+             Diese Methode bewirkt, dass ein Befehlssequenz-Auswahlmenü auf Tastendruck angezeigt wird.
+
+          Advanced Invocation Beispiele: (Bearbeiten der Keymap-Datei):
+             - Direktes Aufrufen einer Befehlsfolge auf Tastendruck, Name ist der Wert, den Sie ihm in den Menüs zugewiesen haben:
+          RunScript(script.commands,,&amp;name=NAME-OF-YOUR-COMMAND-SEQUENCE)
+             - Geben Sie einen anderen Satz von Befehlen an (arbeitet mit oder ohne den Namensparameter)
+          RunScript(script.commands,,&amp;key=NAME-OF-DIFFERENT-COMMAND-SET&amp;name=NAME-OF-YOUR-COMMAND-SEQUENCE)
+      </description>
       <license>GNU GENERAL PUBLIC LICENSE. Version 2, June 1991</license>
       <source>https://github.com/AddonScriptorDE/script.commands</source>
       <forum>http://forum.xbmc.org/showthread.php?tid=134129</forum>

--- a/default.py
+++ b/default.py
@@ -24,7 +24,7 @@ def importCommands(key):
         myCommands.append("- "+translation(30001))
         myCommands.append("- "+translation(30005))
 
-def commandsMain(key):
+def commandsMain(key, name = ""):
         importCommands(key)
         myCommandsTemp=[]
         for temp in myCommands:
@@ -32,8 +32,14 @@ def commandsMain(key):
             myCommandsTemp.append(temp[:temp.find("###")])
           else:
             myCommandsTemp.append(temp)
-        dialog = xbmcgui.Dialog()
-        nr=dialog.select("Commands", myCommandsTemp)
+
+        if name in myCommandsTemp:
+            # skip dialog, run the provided command name directly
+            nr = myCommandsTemp.index(name)
+        else:
+            dialog = xbmcgui.Dialog()
+            nr=dialog.select("Commands", myCommandsTemp)
+
         if nr>=0:
           entry=myCommands[nr]
           if entry.find("###")>=0:
@@ -318,8 +324,13 @@ params=parameters_string_to_dict(sys.argv[2])
 key=params.get('key')
 if type(key)!=type(str()):
   key=''
+# Name is the string name of the command so that it can be executed instantly without
+# presenting a select dialog.
+name=params.get('name')
+if type(name)!=type(str()):
+    name=''
 
 if key != '':
-    commandsMain('_'+key)
+    commandsMain('_'+key, name)
 else:
-    commandsMain('')
+    commandsMain('', name)


### PR DESCRIPTION
New "name=something" parameter that triggers direct execution without showing a dialog.  Tested on Fire TV only with Kodi 17.

Reasoning: I wanted a direct-press action without a menu (that will be usable with the TV off).   In my case, I want it to play a specific predefined mp3 file every time I press a certain key.  (PlayMedia(xyz))

Notes: 
1. I'm not sure why parameters_string_to_dict() starts with the second char, but I left it alone and worked around it with the leading ampersand ( &name=something).   
2. Also I'm not sure why the addon looks at the second parameter and not the first:  RunScript(script.commands,,&name=bla), but I also left that alone...
